### PR TITLE
M01 Fix - do not allow ticket NFTs to be used as collateral

### DIFF
--- a/contracts/NFTLoanFacilitator.sol
+++ b/contracts/NFTLoanFacilitator.sol
@@ -99,6 +99,10 @@ contract NFTLoanFacilitator is Ownable, INFTLoanFacilitator {
         external
         returns(uint256 id) 
     {
+        require(collateralContractAddress != lendTicketContract 
+        && collateralContractAddress != borrowTicketContract, 
+        'NFTLoanFacilitator: cannot use tickets as collateral');
+        
         IERC721(collateralContractAddress).transferFrom(msg.sender, address(this), collateralTokenId);
 
         id = ++_nonce;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -18,11 +18,7 @@ module.exports = {
   networks: {
 	  hardhat: {
 	    chainId: 1337
-	  },
-    rinkeby: {
-      url: `https://eth-rinkeby.alchemyapi.io/v2/${ALCHEMY_RINKEBY_API_KEY}`,
-      accounts: [`0x${RINKEBY_PRIVATE_KEY}`],
-    }
+	  }
  }
 };
 

--- a/test/nftLoanFacilitator.js
+++ b/test/nftLoanFacilitator.js
@@ -108,6 +108,16 @@ describe("NFTLoanFacilitator contract", function () {
                 NFTLoanFacilitator.connect(punkHolder).createLoan(punkId.add(1), CryptoPunks.address, interest, loanAmount, DAI.address, durationSeconds, addr4.address)
             ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved")
         })
+
+        it('reverts if collateral is loan ticket or borrow ticket', async function(){
+            await expect(
+                NFTLoanFacilitator.connect(punkHolder).createLoan(punkId, LendTicket.address, interest, loanAmount, DAI.address, durationSeconds, addr4.address)
+            ).to.be.revertedWith('NFTLoanFacilitator: cannot use tickets as collateral')
+            
+            await expect(
+                NFTLoanFacilitator.connect(punkHolder).createLoan(punkId, BorrowTicket.address, interest, loanAmount, DAI.address, durationSeconds, addr4.address)
+            ).to.be.revertedWith('NFTLoanFacilitator: cannot use tickets as collateral')
+        })
     });
 
     describe("closeLoan", function () {


### PR DESCRIPTION
The contract used to be setup to have an extra step to draw loan or withdrawal loan repayment. When it was like this, it made sense to allow ticket NFTs to be used as collateral. However, now that we've changed this, it is no longer a good idea. Lent funds or repayment might get sent to the loan facilitator and would be stuck there forever. 

This PR adds a check on createLoan to prevent tickets being used as collateral. It increases createLoan gas about ~3k. 