### PR TITLE
Remove unnecessary check in NFTLoanTicket Mint

### DIFF
--- a/contracts/NFTLoanTicket.sol
+++ b/contracts/NFTLoanTicket.sol
@@ -26,7 +26,6 @@ contract NFTLoanTicket is ERC721Enumerable, IMintable {
     }
 
     function mint(address to, uint256 tokenId) loanFacilitatorOnly() override external {
-        require(!_exists(tokenId), "NFTLoanTicket: token with tokenId already exists");
         _mint(to, tokenId);
     }
 

--- a/test/nftLoanTicket.js
+++ b/test/nftLoanTicket.js
@@ -57,7 +57,7 @@ describe("NFTLoanTicket contract", function () {
                     await NFTLoanTicket.connect(pretendNFTLoanFacilitator).mint(addr1.address, "1")
                     await expect(
                         NFTLoanTicket.connect(pretendNFTLoanFacilitator).mint(addr1.address, "1")
-                    ).to.be.revertedWith("NFTLoanTicket: token with tokenId already exists")
+                    ).to.be.revertedWith('ERC721: token already minted')
                     const owner = await NFTLoanTicket.ownerOf("1")
                     expect(owner).to.equal(addr1.address)
                 })


### PR DESCRIPTION
This PR removes a check in `mint` in `NFTLoanTicket` the check was whether the tokenId already exists, but this is already checked by the inherited ERC721 contract