### PR TITLE
N03 fix - make error message format consistent

### DIFF
--- a/contracts/NFTLoanTicket.sol
+++ b/contracts/NFTLoanTicket.sol
@@ -31,7 +31,7 @@ contract NFTLoanTicket is ERC721Enumerable, IMintable {
     }
 
     function tokenURI(uint256 tokenId) public override view returns (string memory) {
-        require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+        require(_exists(tokenId), "NFTLoanTicket: URI query for nonexistent token");
         return descriptor.uri(nftLoanFacilitator, tokenId);
     }
 }

--- a/contracts/descriptors/libraries/HexStrings.sol
+++ b/contracts/descriptors/libraries/HexStrings.sol
@@ -15,6 +15,7 @@ library HexStrings {
             buffer[i] = ALPHABET[value & 0xf];
             value >>= 4;
         }
+        require(value == 0, 'HexStrings: hex length insufficient');
         // uint8 offset 
         buffer[offset + 1] = '.';
         buffer[offset + 2] = '.';
@@ -33,7 +34,7 @@ library HexStrings {
             buffer[i] = ALPHABET[value & 0xf];
             value >>= 4;
         }
-        require(value == 0, 'Strings: hex length insufficient');
+        require(value == 0, 'HexStrings: hex length insufficient');
         return string(buffer);
     }
 }


### PR DESCRIPTION
I made the error message format consistent. I opted, though, not to change the format of the errors in the date time library, as I did not write that code, only changed solidity version requirement, and would like to leave as is. 