### PR TITLE
use safeTransferFrom for nft in repayAndCloseLoan and seizeCollateral

### DIFF
--- a/contracts/NFTLoanFacilitator.sol
+++ b/contracts/NFTLoanFacilitator.sol
@@ -223,7 +223,7 @@ contract NFTLoanFacilitator is Ownable, INFTLoanFacilitator {
         address lender = IERC721(lendTicketContract).ownerOf(loanId);
         loan.closed = true;
         ERC20(loan.loanAssetContractAddress).safeTransferFrom(msg.sender, lender, interest + loan.loanAmount);
-        IERC721(loan.collateralContractAddress).transferFrom(
+        IERC721(loan.collateralContractAddress).safeTransferFrom(
             address(this),
             IERC721(borrowTicketContract).ownerOf(loanId),
             loan.collateralTokenId
@@ -242,7 +242,8 @@ contract NFTLoanFacilitator is Ownable, INFTLoanFacilitator {
         "NFTLoanFacilitator: payment is not late");
 
         loan.closed = true;
-        IERC721(loan.collateralContractAddress).transferFrom(address(this), sendCollateralTo, loan.collateralTokenId);
+        IERC721(loan.collateralContractAddress).safeTransferFrom(address(this), sendCollateralTo, loan.collateralTokenId);
+
         emit SeizeCollateral(loanId);
         emit Close(loanId);
     }


### PR DESCRIPTION
This was flagged in the initial audit report and I opted not to change. Now wondering if worth it. 

One thing is that if the borrow ticket holder is a contract, and the contract does not implement receive for ERC721, the repayment will fail. Probably ok because that contract probably shouldn't be receiving the nft anyway? 